### PR TITLE
allow running as a different user

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -1,0 +1,3 @@
+module example
+
+go 1.16

--- a/example/main.go
+++ b/example/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -29,6 +30,7 @@ func main() {
 	http.HandleFunc("/", home)
 	http.HandleFunc("/curl", curl)
 	http.HandleFunc("/dig", dig)
+	http.HandleFunc("/uid", uid)
 	http.HandleFunc("/resolv.conf", resolvconf)
 	port := "8080"
 	if v := os.Getenv("PORT"); v != "" {
@@ -150,4 +152,8 @@ func dig(w http.ResponseWriter, r *http.Request) {
 func resolvconf(w http.ResponseWriter, r *http.Request) {
 	f, _ := os.Open("/etc/resolv.conf")
 	io.Copy(w, f)
+}
+
+func uid(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "uid:%d", syscall.Getuid())
 }

--- a/runsd/user.go
+++ b/runsd/user.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+)
+
+func resolveUser(uidOrUser string) (uint32, error) {
+	i, err := strconv.ParseUint(uidOrUser, 10, 32)
+	if err == nil {
+		_, err := user.LookupId(uidOrUser)
+		if err != nil {
+			return 0, fmt.Errorf("cannot resolve user %d: %w", i, err)
+		}
+		return uint32(i), nil
+	}
+	u, err := user.Lookup(uidOrUser)
+	if err != nil {
+		return 0, fmt.Errorf("cannot resolve user %q: %w", uidOrUser, err)
+	}
+	i, err = strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse uid %s: %w", u.Uid, err)
+	}
+	return uint32(i), nil
+}


### PR DESCRIPTION
Introducing a -user flag that accepts either a POSIX uid or user name.
This will be used to run the user's application (i.e. the subprocess)

This can be used in the Dockerfile as

    RUN adduser --disabled-password foo
    ENTRYPOINT ["/runsd", "-user=foo", "--", "/myapp"]

or alternatively with a predefined uid:

    RUN adduser --disabled-password --uid 1234 foo
    ENTRYPOINT ["/runsd", "-user=1234", "--", "/myapp"]

Might add support for gid/group name later.
Also adding /uid endpoint to the ./example app to help users try this out.

Resolves #16.